### PR TITLE
Handle the case where the number of keys changes over time.

### DIFF
--- a/tools/prometheus2csv.py
+++ b/tools/prometheus2csv.py
@@ -51,13 +51,22 @@ def print_multi_result(results, label):
             print(', '.join(results[0]['metric'].keys()))
             sys.exit(1)
 
-        headers.append(header)
+        if header not in headers:
+            headers.append(header)
         for value in result['values']:
             data[value[0]][header] = value[1]
 
     print('date,%s' % ','.join(headers))
     for date, values in data.items():
-        print_result(date, ','.join(values.values()))
+        results = ['%s' % date]
+        for header in headers:
+            try:
+                results.append(values[header])
+            except KeyError:
+                # use an empty string rather than 0
+                results.append('')
+                pretty_date = datetime.fromtimestamp(date).strftime('%Y-%m-%d')
+        print(','.join(results))
 
 
 def print_with_labels(results, labels):


### PR DESCRIPTION
I was working on migrating the prometheus data created by the script foundations_errors and discovered a couple of issues with the prometheus2csv conversion tool. The script creates metrics using the names of active releases of Ubuntu (which changes over time) so sometimes there will be no data for a release because it wasn't yet active or it is no longer active. I've resolved this by keeping track of the headers (releases in the this case) and if the header isn't found in the values we just write an empty string for it. Additionally, in the output csv file some column names appeared multiple times so I've made it so we now check to see if its already been added.

You could test this via:

tools/prometheus2csv.py --label series --days 435 --step 12h foundations_bugs_errors_mcp_sum_top_ten > foundations_bugs_errors_mcp_sum_top_ten

and looking at the change in data before and after my modifications.