### PR TITLE
foundations_proposed_migration_by_team: remove useless finally

### DIFF
--- a/metrics/foundations_proposed_migration_by_team.py
+++ b/metrics/foundations_proposed_migration_by_team.py
@@ -65,15 +65,14 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
 
     TEAM = ARGS.team
-    try:
-        DATA = get_proposed_migration_queue(TEAM)
-    finally:
-        if not ARGS.dryrun:
-            print('Pushing data...')
-            util.influxdb_insert([DATA])
-        else:
-            print('Valid candidates: %i' % DATA['fields']['valid_candidates'])
-            print('Not considered candidates: %i' %
-                  DATA['fields']['not_considered'])
-            print('Median age: %i' % DATA['fields']['median_age'])
-            print('Backlog: %i' % DATA['fields']['backlog'])
+    DATA = get_proposed_migration_queue(TEAM)
+
+    if not ARGS.dryrun:
+        print('Pushing data...')
+        util.influxdb_insert([DATA])
+    else:
+        print('Valid candidates: %i' % DATA['fields']['valid_candidates'])
+        print('Not considered candidates: %i' %
+              DATA['fields']['not_considered'])
+        print('Median age: %i' % DATA['fields']['median_age'])
+        print('Backlog: %i' % DATA['fields']['backlog'])


### PR DESCRIPTION
The finally clause here relied on a variable set in the only line in the
try clause; if we encounter an exception, we'll immediately get a (less
useful) traceback in the finally clause, so there's no point having it.