### PR TITLE
foundations_retracers_*: exit 0 for non-today results

### DIFF
--- a/metrics/foundations_retracers_avg_time.py
+++ b/metrics/foundations_retracers_avg_time.py
@@ -37,7 +37,7 @@ def collect(environment, dryrun=False):
         sys.exit(1)
     if retrace_time_json['objects'][0]['date'] != YESTERDAY.strftime('%Y%m%d'):
         print("The results are not for today, quitting.")
-        sys.exit(1)
+        sys.exit(0)
 
     results = retrace_time_json['objects'][0]['value']
     for release in results:

--- a/metrics/foundations_retracers_results.py
+++ b/metrics/foundations_retracers_results.py
@@ -36,7 +36,7 @@ def collect(environment, dryrun=False):
         sys.exit(1)
     if retrace_results_json['objects'][0]['date'] != TODAY.strftime('%Y%m%d'):
         print("The results are not for today, quitting.")
-        sys.exit(1)
+        sys.exit(0)
 
     results = retrace_results_json['objects'][0]['value']
     for value in results:


### PR DESCRIPTION
This appears to be a state we can get in to readily (i.e. if we run
after midnight), so we shouldn't get failure notifications for it.