### PR TITLE
proposed_migration_by_team: use yaml.load() instead of .safe_load()

### DIFF
--- a/metrics/foundations_proposed_migration_by_team.py
+++ b/metrics/foundations_proposed_migration_by_team.py
@@ -20,7 +20,7 @@ def get_proposed_migration_queue(team):
             logging.error('URL %s failed with code %u', req.geturl(), code)
             return {}
         yamldata = StringIO(req.read().decode('UTF-8'))
-    yaml_handle = yaml.safe_load(yamldata)
+    yaml_handle = yaml.load(yamldata)
     valid = 0
     not_considered = 0
     ages = []

--- a/metrics/foundations_proposed_migration_by_team.py
+++ b/metrics/foundations_proposed_migration_by_team.py
@@ -20,7 +20,7 @@ def get_proposed_migration_queue(team):
             logging.error('URL %s failed with code %u', req.geturl(), code)
             return {}
         yamldata = StringIO(req.read().decode('UTF-8'))
-    yaml_handle = yaml.load(yamldata)
+    yaml_handle = yaml.load(yamldata, Loader=yaml.Loader)
     valid = 0
     not_considered = 0
     ages = []


### PR DESCRIPTION
The yaml now includes rich data for deserialisation, but by design
yaml.safe_load() does not handle it. Let's switch to yaml.load()
with `Loader=yaml.Loader` as the data source is trusted.

Thanks: Björn Tillenius, Daniel Watkins